### PR TITLE
Feature/process count

### DIFF
--- a/booktest/reports.py
+++ b/booktest/reports.py
@@ -161,6 +161,7 @@ class CaseReports:
                    duration):
         file_handle.write(
             f"{case_name}\t{res.name}\t{duration}\n")
+        file_handle.flush()
 
     def to_dir(self, out_dir):
         report_file = os.path.join(out_dir, "cases.txt")

--- a/booktest/runs.py
+++ b/booktest/runs.py
@@ -90,6 +90,13 @@ class ParallelRunner:
                  config: dict,
                  reports: CaseReports):
         self.cases = cases
+        process_count = config.get("parallel", True)
+        if process_count is True or process_count == "True":
+            process_count = os.cpu_count()
+        else:
+            process_count = int(process_count)
+
+        self.process_count = process_count
         self.pool = None
         self.done = set()
         self.case_durations = {}
@@ -225,7 +232,7 @@ class ParallelRunner:
     def __enter__(self):
         import coverage
         self.finished = False
-        self.pool = Pool(os.cpu_count(), initializer=coverage.process_startup)
+        self.pool = Pool(self.process_count, initializer=coverage.process_startup)
         self.pool.__enter__()
 
         self.thread = threading.Thread(target=self.thread_function)

--- a/booktest/tests.py
+++ b/booktest/tests.py
@@ -164,7 +164,62 @@ class Tests:
         parser.add_argument(
             "-p",
             action='store_true',
-            help="run test on parallel processes"
+            help="run test on N parallel processes, where is N relative to CPU count"
+        )
+        parser.add_argument(
+            "-p1",
+            dest='p',
+            action='store_const',
+            const=1,
+            help="run test on 1 parallel processes"
+        )
+        parser.add_argument(
+            "-p2",
+            dest='p',
+            action='store_const',
+            const=2,
+            help="run test on 2 parallel processes"
+        )
+        parser.add_argument(
+            "-p3",
+            dest='p',
+            action='store_const',
+            const=3,
+            help="run test on 3 parallel processes"
+        )
+        parser.add_argument(
+            "-p4",
+            dest='p',
+            action='store_const',
+            const=4,
+            help="run test on 4 parallel processes"
+        )
+        parser.add_argument(
+            "-p6",
+            dest='p',
+            action='store_const',
+            const=6,
+            help="run test on 6 parallel processes"
+        )
+        parser.add_argument(
+            "-p8",
+            dest='p',
+            action='store_const',
+            const=8,
+            help="run test on 8 parallel processes"
+        )
+        parser.add_argument(
+            "-p16",
+            dest='p',
+            action='store_const',
+            const='16',
+            help="run test on 16 parallel processes"
+        )
+        parser.add_argument(
+            "--parallel-count",
+            dest='p',
+            type=int,
+            help="run test on N parallel processes"
         )
         parser.add_argument(
             "-s",
@@ -316,7 +371,7 @@ class Tests:
         if parsed.a:
             config["accept"] = True
         if parsed.p:
-            config["parallel"] = True
+            config["parallel"] = parsed.p
         if parsed.s:
             config["complete_snapshots"] = True
         if parsed.S:

--- a/booktest/tests.py
+++ b/booktest/tests.py
@@ -6,6 +6,7 @@ from coverage import Coverage
 
 from booktest.cache import LruCache
 from booktest.dependencies import bind_dependent_method_if_unbound
+from booktest.reports import CaseReports
 from booktest.review import run_tool, review
 from booktest.runs import parallel_run_tests, run_tests
 from booktest.config import get_default_config
@@ -250,6 +251,7 @@ class Tests:
             dest='cmd',
             const="-l",
             help="lists the selected test cases")
+
         parser.add_argument(
             "--setup",
             action='store_const',
@@ -417,6 +419,9 @@ class Tests:
 
         cases = self.selected_names(selection, cache_out_dir)
 
+        reports = CaseReports.of_dir(out_dir)
+        done, todo = reports.cases_to_done_and_todo(cases, config)
+
         cmd = parsed.cmd
 
         if cmd == '--setup':
@@ -430,13 +435,13 @@ class Tests:
                 print(f"{p}")
             return 0
         elif cmd == '--print':
-            for name in cases:
+            for name in todo:
                 file = path.join(exp_dir, f"{name}.md")
                 if path.exists(file):
                     os.system(f"cat {file}")
             return 0
         elif cmd == '--path':
-            for name in cases:
+            for name in todo:
                 file = path.join(exp_dir, f"{name}.md")
                 print(file)
             return 0
@@ -456,7 +461,7 @@ class Tests:
                 print(f"removed {p}")
             return 0
         elif cmd == '-l':
-            for s in cases:
+            for s in todo:
                 print(f"  {s}")
             return 0
         elif cmd == '--review':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "booktest"
-version = "0.3.20"
+version = "0.3.21"
 authors = ["Antti Rauhala <antti@lumoa.me>"]
 description = "Booktest is a snapshot testing library for review driven testing."
 readme = "readme.md"


### PR DESCRIPTION
Lots of ergonomics changes to parallel runs: 

 * The number of processes can now be configured. This helps avoid slowing computer down or running out of RAM
 * When in interactive and parallel mode, the run, but not tested cases will also be saved in the review record for e.g later review
 * Reviews are now stored immediately to disk to avoid losing information
 * Also -c flag affect list returns, so that you can see only the cases that will be run