### PR TITLE
https/requests snapshots print order was made deterministic.

### DIFF
--- a/books/test/examples/snapshots/httpx_sequence.md
+++ b/books/test/examples/snapshots/httpx_sequence.md
@@ -13,5 +13,5 @@ following requests should provide different answer
 
 # httpx snaphots:
 
- * https://timeapi.io/api/time/current/zone?timeZone=Europe%2FAmsterdam - 58cb3f3a03b057645d8aa5d98f3d21578933e363
  * https://timeapi.io/api/time/current/zone?timeZone=Europe%2FAmsterdam - 3a6b8838042eb5a710065a1c8ee8cac0b6e0099f
+ * https://timeapi.io/api/time/current/zone?timeZone=Europe%2FAmsterdam - 58cb3f3a03b057645d8aa5d98f3d21578933e363

--- a/books/test/examples/snapshots/httpx_sequence/.httpx.json
+++ b/books/test/examples/snapshots/httpx_sequence/.httpx.json
@@ -12,7 +12,8 @@
                 "content-type": "application/json; charset=utf-8",
                 "transfer-encoding": "chunked",
                 "connection": "keep-alive",
-                "vary": "Accept-Encoding"
+                "vary": "Accept-Encoding",
+                "content-length": "228"
             },
             "statusCode": 200,
             "content": "eyJ5ZWFyIjoyMDI0LCJtb250aCI6OSwiZGF5IjoyNywiaG91ciI6MTUsIm1pbnV0ZSI6NCwic2Vjb25kcyI6MTIsIm1pbGxpU2Vjb25kcyI6OTEwLCJkYXRlVGltZSI6IjIwMjQtMDktMjdUMTU6MDQ6MTIuOTEwODI0IiwiZGF0ZSI6IjA5LzI3LzIwMjQiLCJ0aW1lIjoiMTU6MDQiLCJ0aW1lWm9uZSI6IkV1cm9wZS9BbXN0ZXJkYW0iLCJkYXlPZldlZWsiOiJGcmlkYXkiLCJkc3RBY3RpdmUiOnRydWV9"
@@ -32,7 +33,8 @@
                 "content-type": "application/json; charset=utf-8",
                 "transfer-encoding": "chunked",
                 "connection": "keep-alive",
-                "vary": "Accept-Encoding"
+                "vary": "Accept-Encoding",
+                "content-length": "229"
             },
             "statusCode": 200,
             "content": "eyJ5ZWFyIjoyMDI0LCJtb250aCI6OSwiZGF5IjoyNywiaG91ciI6MTUsIm1pbnV0ZSI6NCwic2Vjb25kcyI6MTMsIm1pbGxpU2Vjb25kcyI6MTgwLCJkYXRlVGltZSI6IjIwMjQtMDktMjdUMTU6MDQ6MTMuMTgwODQyNCIsImRhdGUiOiIwOS8yNy8yMDI0IiwidGltZSI6IjE1OjA0IiwidGltZVpvbmUiOiJFdXJvcGUvQW1zdGVyZGFtIiwiZGF5T2ZXZWVrIjoiRnJpZGF5IiwiZHN0QWN0aXZlIjp0cnVlfQ=="

--- a/books/test/examples/snapshots/requests_sequence.md
+++ b/books/test/examples/snapshots/requests_sequence.md
@@ -13,5 +13,5 @@ following requests should provide different answer
 
 # request snaphots:
 
- * https://timeapi.io/api/time/current/zone?timeZone=Europe%2FAmsterdam - 61a85a10ba34bfb5cdee47cba501dee356846bbb
  * https://timeapi.io/api/time/current/zone?timeZone=Europe%2FAmsterdam - 1ae53133617f92562bda2414f19d09faae5774f3
+ * https://timeapi.io/api/time/current/zone?timeZone=Europe%2FAmsterdam - 61a85a10ba34bfb5cdee47cba501dee356846bbb

--- a/books/test/examples/snapshots/requests_with_headers.md
+++ b/books/test/examples/snapshots/requests_with_headers.md
@@ -92,9 +92,9 @@ one snapshot is used twice.
 
 # request snaphots:
 
- * https://httpbin.org/anything - d360944caa4275ee6fb2da7159894b4ed90cd17f
  * https://httpbin.org/anything - 3f887fcebc089421e4713ef161004859c8007d29
  * https://httpbin.org/anything - 655d501f55408bce98f364383a5f1d6b5378e30b
+ * https://httpbin.org/anything - d360944caa4275ee6fb2da7159894b4ed90cd17f
 
 # env snaphots:
 

--- a/booktest/httpx.py
+++ b/booktest/httpx.py
@@ -310,7 +310,7 @@ class SnapshotHttpx:
 
     def t_snapshots(self):
         self.t.h1("httpx snaphots:")
-        for i in self.requests:
+        for i in sorted(self.requests, key=lambda i: (i.request.url(), i.hash())):
             self.t.tln(f" * {i.request.url()} - {i.hash()}")
 
     def __enter__(self):

--- a/booktest/requests.py
+++ b/booktest/requests.py
@@ -369,7 +369,7 @@ class SnapshotRequests:
 
     def t_snapshots(self):
         self.t.h1("request snaphots:")
-        for i in self._adapter.requests:
+        for i in sorted(self._adapter.requests, key=lambda i: (i.request.url(), i.hash())):
             self.t.tln(f" * {i.request.url()} - {i.hash()}")
 
     def __enter__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "booktest"
-version = "0.3.38"
+version = "0.3.39"
 authors = ["Antti Rauhala <antti@lumoa.me>"]
 description = "Booktest is a snapshot testing library for review driven testing."
 readme = "readme.md"


### PR DESCRIPTION
The printed snapshot order may falsely break tests in parallel settings, where the request order is non-deterministic.   