### PR TITLE
Replace print() with logging in migration module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-02-27
+
+### Fixed
+- Migration module `print()` output no longer leaks into test runner output (replaced with `logging`)
+
 ## [1.1.2] - 2026-02-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "booktest"
-version = "1.1.2"
+version = "1.1.3"
 authors = [{name = "Antti Rauhala", email = "antti@lumoa.me"}]
 description = "Booktest is a snapshot testing library for review driven testing."
 readme = "readme.md"


### PR DESCRIPTION
Migration status messages were leaking into test output during test runs. Use Python logging module instead so they go to the log file.

## Description

Describe your changes here.

## Related Issue

Fixes #(issue number) or Related to #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Checklist

- [ ] I have run `./do lint` and fixed any issues
- [ ] I have run `./do test` and all tests pass
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)
