### PR TITLE
Fix async detection for callable class instances

### DIFF
--- a/books/test/cli_test.py/test_failures.md
+++ b/books/test/cli_test.py/test_failures.md
@@ -44,13 +44,13 @@ test book/failing_book.py::test_decorated_async_exception
     File "<workdir>/booktest/core/testrun.py", line 105, in run_case
       rv = await maybe_async_call(case, [t], {})
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    File "<workdir>/booktest/utils/coroutines.py", line 6, in maybe_async_call
+    File "<workdir>/booktest/utils/coroutines.py", line 11, in maybe_async_call
       return await func(*args2, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "<workdir>/booktest/snapshots/env.py", line 248, in wrapper
       return await maybe_async_call(func , args, kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    File "<workdir>/booktest/utils/coroutines.py", line 6, in maybe_async_call
+    File "<workdir>/booktest/utils/coroutines.py", line 11, in maybe_async_call
       return await func(*args2, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "<workdir>/examples/failures/book/failing_book.py", line 35, in test_decorated_async_exception
@@ -70,13 +70,13 @@ test book/failing_book.py::test_decorated_exception
     File "<workdir>/booktest/core/testrun.py", line 105, in run_case
       rv = await maybe_async_call(case, [t], {})
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    File "<workdir>/booktest/utils/coroutines.py", line 6, in maybe_async_call
+    File "<workdir>/booktest/utils/coroutines.py", line 11, in maybe_async_call
       return await func(*args2, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "<workdir>/booktest/snapshots/env.py", line 248, in wrapper
       return await maybe_async_call(func , args, kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    File "<workdir>/booktest/utils/coroutines.py", line 8, in maybe_async_call
+    File "<workdir>/booktest/utils/coroutines.py", line 13, in maybe_async_call
       return func(*args2, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^
     File "<workdir>/examples/failures/book/failing_book.py", line 29, in test_decorated_exception
@@ -96,7 +96,7 @@ test book/failing_book.py::test_exception
     File "<workdir>/booktest/core/testrun.py", line 105, in run_case
       rv = await maybe_async_call(case, [t], {})
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    File "<workdir>/booktest/utils/coroutines.py", line 8, in maybe_async_call
+    File "<workdir>/booktest/utils/coroutines.py", line 13, in maybe_async_call
       return func(*args2, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^
     File "<workdir>/examples/failures/book/failing_book.py", line 23, in test_exception
@@ -124,13 +124,13 @@ test book/failing_book.py::test_memory_monitor_exception
     File "<workdir>/booktest/core/testrun.py", line 105, in run_case
       rv = await maybe_async_call(case, [t], {})
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    File "<workdir>/booktest/utils/coroutines.py", line 6, in maybe_async_call
+    File "<workdir>/booktest/utils/coroutines.py", line 11, in maybe_async_call
       return await func(*args2, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "<workdir>/booktest/dependencies/memory.py", line 66, in wrapper
       rv = await maybe_async_call(func , args, kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    File "<workdir>/booktest/utils/coroutines.py", line 6, in maybe_async_call
+    File "<workdir>/booktest/utils/coroutines.py", line 11, in maybe_async_call
       return await func(*args2, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     File "<workdir>/examples/failures/book/failing_book.py", line 41, in test_memory_monitor_exception

--- a/booktest/utils/coroutines.py
+++ b/booktest/utils/coroutines.py
@@ -2,7 +2,12 @@ import inspect
 
 
 async def maybe_async_call(func, args2, kwargs):
-    if inspect.iscoroutinefunction(func):
+    # Check if func itself is a coroutine function, or if it's a callable
+    # object with an async __call__ method
+    is_coro = inspect.iscoroutinefunction(func) or \
+              inspect.iscoroutinefunction(getattr(func, '__call__', None))
+
+    if is_coro:
         return await func(*args2, **kwargs)
     else:
         return func(*args2, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "booktest"
-version = "1.1.3"
+version = "1.1.4"
 authors = [{name = "Antti Rauhala", email = "antti@lumoa.me"}]
 description = "Booktest is a snapshot testing library for review driven testing."
 readme = "readme.md"


### PR DESCRIPTION
## Summary

- Fix `maybe_async_call()` to properly detect `async def __call__` methods on callable class instances
- Previously `inspect.iscoroutinefunction(func)` returned `False` for callable objects, causing coroutines to never be awaited
- This enables pickleable callable classes with async `__call__` for parallel test execution

## Test plan

- [x] Verified AsyncCallable, SyncCallable, async functions, and sync functions all work correctly
- [x] All existing tests pass
- [x] Snapshot updated for traceback line number changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)